### PR TITLE
Adicionando os 4 bytes do tamanho da mensagem na verificação

### DIFF
--- a/novo_texto.txt
+++ b/novo_texto.txt
@@ -16,4 +16,4 @@ Com um desejo maciço e permanente.
 
 E de te amar assim muito e amiúde,
 É que um dia em teu corpo de repente
-Hei de morrer de amar mais do que p
+Hei de morrer de amar mais do que pude.

--- a/shadow_decoder.php
+++ b/shadow_decoder.php
@@ -55,11 +55,11 @@ for ($i = 0; $i < $width; $i++) {
     for ($j = 0; $j < $height; $j++) {
 
         // Verifique se a mensagem já foi totalmente decodificada
-        if (strlen($mensagem) >= $tamanhoMensagem) {
+        if (strlen($mensagem) >= $tamanhoMensagem + 4) {
             break 2; // Saia dos loops
         }
 
-        // Recupera o pixel i,j da imagem 
+        // Recupera o pixel i,j da imagem
         $pixel = imagecolorat($im, $i, $j);
 
         // Extrai os valores de vermelho, verde e azul do pixel


### PR DESCRIPTION
Para que o texto todo seja salvo, na verificação se a mensagem foi totalmente decodificada, os 4 bytes iniciais precisam ser levados em consideração.